### PR TITLE
[#89] fix: KakaoProfile 변수 추가

### DIFF
--- a/src/main/java/com/gongjakso/server/global/security/kakao/dto/KakaoProfile.java
+++ b/src/main/java/com/gongjakso/server/global/security/kakao/dto/KakaoProfile.java
@@ -31,7 +31,8 @@ public record KakaoProfile(
                 String nickname,
                 String thumbnail_image_url,
                 String profile_image_url,
-                Boolean is_default_image
+                Boolean is_default_image,
+                Boolean is_default_nickname
         ) {
         }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #89 

## 📝 작업 내용
- kakao에서 토큰 기반으로 사용자 정보를 요청 시, is_default_nickname이라는 변수도 반환하는 것을 확인, 이에 따라 KAKAO로 전달받은 응답을 Mapping하는 DTO에 is_default_nickname 변수 추가

### 스크린샷 (선택)
<img width="1053" alt="image" src="https://github.com/Gongjakso/server/assets/76556999/1cf280bd-5b6a-48d4-9ca3-71dd8a08172a">


## 💬 리뷰 요구사항(선택)
