### PR TITLE
feat: 지원한 공고 리스트 조회 및 공고 접근 시 확인하는 API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ docker-compose.yml
 monitoring-docker-compose.yml
 prometheus.yml
 **/application.yml
+
+__default__.tmpl
+grafana.db

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/MyPageRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/MyPageRes.java
@@ -1,7 +1,8 @@
 package com.gongjakso.server.domain.apply.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.gongjakso.server.domain.member.entity.Member;
+import com.gongjakso.server.domain.apply.entity.Apply;
+import com.gongjakso.server.domain.apply.enumerate.ApplyType;
 import com.gongjakso.server.domain.post.entity.Post;
 import com.gongjakso.server.domain.post.enumerate.PostStatus;
 import lombok.Builder;
@@ -19,6 +20,7 @@ public record MyPageRes(
         String title,
         String contents,
         PostStatus status,
+        ApplyType applyType,
         LocalDateTime startDate,
         LocalDateTime endDate,
         Long daysRemaining,
@@ -27,7 +29,7 @@ public record MyPageRes(
         Long scrapCount
 
 ) {
-    public static MyPageRes of(Post post, Member member, List<String> categoryList) {
+    public static MyPageRes of(Post post, Apply apply, List<String> categoryList) {
         return MyPageRes.builder()
                 .postId(post.getPostId())
                 .memberId(post.getMember().getMemberId())
@@ -35,6 +37,7 @@ public record MyPageRes(
                 .title(post.getTitle())
                 .contents(post.getContents())
                 .status(post.getStatus())
+                .applyType(apply.getApplyType())
                 .startDate(post.getStartDate())
                 .endDate(post.getEndDate())
                 .daysRemaining(post.getFinishDate().isBefore(LocalDateTime.now()) ? -1 : ChronoUnit.DAYS.between(LocalDateTime.now(), post.getFinishDate()))

--- a/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
@@ -3,9 +3,7 @@ package com.gongjakso.server.domain.apply.service;
 import com.gongjakso.server.domain.apply.dto.*;
 import com.gongjakso.server.domain.apply.entity.Apply;
 import com.gongjakso.server.domain.apply.enumerate.ApplyType;
-import com.gongjakso.server.domain.apply.enumerate.StackType;
 import com.gongjakso.server.domain.apply.repository.ApplyRepository;
-import com.gongjakso.server.domain.banner.entity.Banner;
 import com.gongjakso.server.domain.member.entity.Member;
 import com.gongjakso.server.domain.post.entity.Category;
 import com.gongjakso.server.domain.post.entity.Post;
@@ -236,20 +234,18 @@ public class ApplyService {
 
         // Business Logic
         List<Apply> applyList = applyRepository.findAllByMemberAndDeletedAtIsNull(member);
-        List<Long> postIdList = applyList.stream()
-                .map(apply -> apply.getPost().getPostId())
-                .toList();
 
-        List<Post> postList = postRepository.findAllByPostIdInAndStatusAndDeletedAtIsNull(postIdList, RECRUITING);
 
         // Response
-        return postList.stream()
-                .map(post -> {
+        return applyList.stream()
+                .filter(apply -> apply.getPost().getStatus() == PostStatus.RECRUITING)
+                .map(apply -> {
+                    Post post = apply.getPost();
                     List<String> categoryList = post.getCategories().stream()
                             .map(category -> category.getCategoryType().toString())
                             .toList();
 
-                    return MyPageRes.of(post, member, categoryList);
+                    return MyPageRes.of(post, apply, categoryList);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/gongjakso/server/domain/post/controller/PostController.java
+++ b/src/main/java/com/gongjakso/server/domain/post/controller/PostController.java
@@ -99,4 +99,10 @@ public class PostController {
     public ApplicationResponse<List<MyPageRes>> getMyPostList(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         return ApplicationResponse.ok(postService.getMyPostList(principalDetails.getMember()));
     }
+
+    @Operation(summary = "공고와 관련된 유저인지를 확인하는 API", description = "팀장이거나, 신청자인 경우를 확인해서 결과로 반환")
+    @GetMapping("/check/{post_id}")
+    public ApplicationResponse<GetPostRelation> checkPostRelation(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("post_id") Long postId) {
+        return ApplicationResponse.ok(postService.checkPostRelation(principalDetails.getMember(), postId));
+    }
 }

--- a/src/main/java/com/gongjakso/server/domain/post/dto/GetPostRelation.java
+++ b/src/main/java/com/gongjakso/server/domain/post/dto/GetPostRelation.java
@@ -1,0 +1,15 @@
+package com.gongjakso.server.domain.post.dto;
+
+import com.gongjakso.server.domain.post.entity.Post;
+import lombok.Builder;
+
+@Builder
+public record GetPostRelation(
+        String status
+) {
+    public static GetPostRelation of(String status) {
+        return GetPostRelation.builder()
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/gongjakso/server/domain/post/service/PostService.java
+++ b/src/main/java/com/gongjakso/server/domain/post/service/PostService.java
@@ -353,4 +353,23 @@ public class PostService {
         // Return
         return myPageResList;
     }
+
+    public GetPostRelation checkPostRelation(Member member, Long postId) {
+        // Validation
+        Post post = postRepository.findByPostIdAndDeletedAtIsNull(postId).orElseThrow(() -> new ApplicationException(ALREADY_DELETE_EXCEPTION));
+
+        // Business Logic
+        String status = "GENERAL";
+        if(post.getMember().getMemberId().equals(member.getMemberId())){
+            status = "LEADER";
+        }
+        else {
+            if(applyRepository.existsApplyByMemberAndPost(member, post)) {
+             status = "APPLICANT";
+            }
+        }
+
+        // Return
+        return GetPostRelation.of(status);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #98 

## 📝 작업 내용
- 내가 지원한 공고 리스트 조회하는 API에서 합류 현황 정보 추가
- 공고 접근 시, 공고 유관자인지 확인하는 API

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
