### PR TITLE
fix: 지원 취소 API 추가 및 관련 API 로직 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/gongjakso/server/domain/apply/controller/ApplyController.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/controller/ApplyController.java
@@ -113,7 +113,7 @@ public class ApplyController {
     }
 
     @Operation(summary = "지원 취소 API", description = "해당 공고에 대한 지원을 취소한다.")
-    @PatchMapping("/{apply_id}/cancel")
+    @PatchMapping("/cancel/{apply_id}")
     public ApplicationResponse<PatchApplyRes> cancelApply(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("apply_id") Long applyId){
         return ApplicationResponse.ok(applyService.cancelApply(principalDetails.getMember(), applyId));
     }

--- a/src/main/java/com/gongjakso/server/domain/apply/controller/ApplyController.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/controller/ApplyController.java
@@ -111,4 +111,10 @@ public class ApplyController {
     public ApplicationResponse<ApplicationRes> getMyApplication(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("post_id") Long postId){
         return ApplicationResponse.ok(applyService.getMyApplication(principalDetails.getMember(), postId));
     }
+
+    @Operation(summary = "지원 취소 API", description = "해당 공고에 대한 지원을 취소한다.")
+    @PatchMapping("/{apply_id}/cancel")
+    public ApplicationResponse<PatchApplyRes> cancelApply(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("apply_id") Long applyId){
+        return ApplicationResponse.ok(applyService.cancelApply(principalDetails.getMember(), applyId));
+    }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/ApplicationRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/ApplicationRes.java
@@ -12,11 +12,11 @@ import java.util.List;
 public record ApplicationRes(
         Long applyId,
         ApplyType applyType,
-        String member_name,
+        String memberName,
         String major,
         String phone,
         String application,
-        String recruit_part,
+        String recruitPart,
         List<String> category,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         List<String> postStack,
@@ -25,7 +25,18 @@ public record ApplicationRes(
         List<String> applyStack
 
 ) {
-    public static ApplicationRes of(Apply apply, List<String> category,List<String> stackName,List<String> applyStack){
-        return new ApplicationRes(apply.getApplyId(), apply.getApplyType(),apply.getMember().getMajor(),apply.getApplication(), apply.getRecruit_part(), category, stackName,applyStack);
+    public static ApplicationRes of(Apply apply, List<String> category, List<String> stackName, List<String> applyStack) {
+        return ApplicationRes.builder()
+                .applyId(apply.getApplyId())
+                .applyType(apply.getApplyType())
+                .memberName(apply.getMember().getName())
+                .major(apply.getMember().getMajor())
+                .phone(apply.getMember().getPhone())
+                .application(apply.getApplication())
+                .recruitPart(apply.getRecruit_part())
+                .category(category)
+                .postStack(stackName)
+                .applyStack(applyStack)
+                .build();
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/ApplicationRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/ApplicationRes.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Builder
 public record ApplicationRes(
+        Long applyId,
         ApplyType applyType,
         String major,
         String application,
@@ -23,6 +24,6 @@ public record ApplicationRes(
 
 ) {
     public static ApplicationRes of(Apply apply, List<String> category,List<String> stackName,List<String> applyStack){
-        return new ApplicationRes(apply.getApplyType(),apply.getMember().getMajor(),apply.getApplication(), apply.getRecruit_part(), category, stackName,applyStack);
+        return new ApplicationRes(apply.getApplyId(), apply.getApplyType(),apply.getMember().getMajor(),apply.getApplication(), apply.getRecruit_part(), category, stackName,applyStack);
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/ApplyList.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/ApplyList.java
@@ -1,13 +1,21 @@
 package com.gongjakso.server.domain.apply.dto;
 
 import com.gongjakso.server.domain.apply.entity.Apply;
+import lombok.Builder;
 
+@Builder
 public record ApplyList(
     Long apply_id,
     String name,
-    String state
+    String state,
+    Boolean is_canceled
 ) {
     public static ApplyList of(Apply apply,String state){
-        return new ApplyList(apply.getApplyId(),apply.getMember().getName(),state);
+        return ApplyList.builder()
+                .apply_id(apply.getApplyId())
+                .name(apply.getMember().getName())
+                .state(state)
+                .is_canceled(apply.getIsCanceled())
+                .build();
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/PatchApplyRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/PatchApplyRes.java
@@ -1,0 +1,33 @@
+package com.gongjakso.server.domain.apply.dto;
+
+import com.gongjakso.server.domain.apply.entity.Apply;
+import com.gongjakso.server.domain.apply.enumerate.ApplyType;
+import com.gongjakso.server.domain.apply.enumerate.PostType;
+import com.gongjakso.server.domain.member.entity.Member;
+import lombok.Builder;
+
+@Builder
+public record PatchApplyRes(
+        Long applyId,
+        Long memberId,
+        String memberName,
+        Long postId,
+        String application,
+        String recruitPart,
+        PostType type,
+        ApplyType applyType,
+        Boolean isCanceled
+) {
+
+    public static PatchApplyRes of(Apply apply, Member member) {
+        return PatchApplyRes.builder()
+                .applyId(apply.getApplyId())
+                .memberId(apply.getMember().getMemberId())
+                .memberName(member.getName())
+                .postId(apply.getPost().getPostId())
+                .application(apply.getApplication())
+                .applyType(apply.getApplyType())
+                .recruitPart(apply.getRecruit_part())
+                .build();
+    }
+}

--- a/src/main/java/com/gongjakso/server/domain/apply/dto/PatchApplyRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/PatchApplyRes.java
@@ -1,5 +1,6 @@
 package com.gongjakso.server.domain.apply.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gongjakso.server.domain.apply.entity.Apply;
 import com.gongjakso.server.domain.apply.enumerate.ApplyType;
 import com.gongjakso.server.domain.apply.enumerate.PostType;
@@ -7,6 +8,7 @@ import com.gongjakso.server.domain.member.entity.Member;
 import lombok.Builder;
 
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PatchApplyRes(
         Long applyId,
         Long memberId,
@@ -28,6 +30,7 @@ public record PatchApplyRes(
                 .application(apply.getApplication())
                 .applyType(apply.getApplyType())
                 .recruitPart(apply.getRecruit_part())
+                .isCanceled(apply.getIsCanceled())
                 .build();
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/entity/Apply.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/entity/Apply.java
@@ -39,14 +39,21 @@ public class Apply extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ApplyType applyType;
 
+    @Column(name = "is_canceled", nullable = false)
+    private Boolean isCanceled;
+
+    public void updateIsCanceled(Boolean isCanceled) {
+        this.isCanceled = isCanceled;
+    }
+
     @Builder
-    public Apply(Long applyId, Member member,Post post,String application,String recruit_part,PostType type, ApplyType applyType){
-        this.applyId=applyId;
+    public Apply(Member member,Post post,String application,String recruit_part,PostType type, ApplyType applyType){
         this.member=member;
         this.post=post;
         this.application=application;
         this.recruit_part=recruit_part;
         this.type=type;
         this.applyType=applyType;
+        this.isCanceled= Boolean.FALSE;
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
@@ -9,12 +9,21 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ApplyRepository extends JpaRepository<Apply,Long> {
+
     long countApplyWithStackNameUsingFetchJoinByPost(Post post);
+
     boolean existsApplyByMemberAndPost(Member member,Post post);
+
     Page<Apply> findAllByPost(Post post, Pageable pageable);
+
     Page<Apply> findApplyByApplyType(ApplyType applyType, Pageable pageable);
+
     List<Apply> findAllByMemberAndDeletedAtIsNull(Member member);
+
     Apply findApplyByMemberAndPost(Member member,Post post);
+
+    Optional<Apply> findApplyByApplyIdAndDeletedAtIsNull(Long applyId);
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
@@ -206,7 +206,6 @@ public class ApplyService {
         return ParticipationPageRes.of(participationLists, pageNo, size, totalPages, last);
     }
 
-    @Transactional
     private String decisionState(Apply apply) {
         if (apply.getApplyType().equals(ApplyType.OPEN_APPLY)) {
             return "열람 완료";

--- a/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
@@ -51,11 +51,9 @@ public class ApplyService {
     private final EmailClient emailClient;
 
     @Transactional
-    public void save(Member member, Long post_id, ApplyReq req) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post==null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+    public void save(Member member, Long postId, ApplyReq req) {
+        // Validation
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         //Check reapply
         if (applyRepository.existsApplyByMemberAndPost(member, post)) {
             throw new ApplicationException(ErrorCode.ALREADY_APPLY_EXCEPTION);
@@ -65,11 +63,9 @@ public class ApplyService {
             throw new ApplicationException(ErrorCode.NOT_APPLY_EXCEPTION);
         }
 
-
         Apply apply = req.toEntity(member, post);
         applyRepository.save(apply);
         if(post.isPostType()){
-            System.out.println("project");
             for(String stackNameType : req.stack()){
                 //StackNameType인지 판단
                 if (!StackNameType.isValid(stackNameType)){
@@ -82,12 +78,9 @@ public class ApplyService {
         }
     }
 
-    public ApplyRes findApply(Member member,Long post_id) {
+    public ApplyRes findApply(Member member,Long postId) {
         //Get Post
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if (post == null) {
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         if(post.getMember()!=member){
             throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
@@ -99,11 +92,8 @@ public class ApplyService {
         return ApplyRes.of(post, current_person, categoryList);
     }
 
-    public CategoryRes findPostCategory(Long post_id) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post==null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+    public CategoryRes findPostCategory(Long postId) {
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
 
         //Change List Type
         List<String> categoryList = changeCategoryType(post);
@@ -118,12 +108,9 @@ public class ApplyService {
 
     }
 
-    public ApplicationRes findApplication(Member member, Long apply_id, Long post_id) {
+    public ApplicationRes findApplication(Member member, Long apply_id, Long postId) {
         Apply apply = applyRepository.findById(apply_id).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_APPLY_EXCEPTION));
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post==null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
 
         //Check leader
         if (!Objects.equals(post.getMember().getMemberId(), member.getMemberId())) {
@@ -175,11 +162,8 @@ public class ApplyService {
         return stringTypelist;
     }
 
-    public ApplyPageRes applyListPage(Member member, long post_id, int page, int size) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post == null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+    public ApplyPageRes applyListPage(Member member, long postId, int page, int size) {
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         if(!post.getMember().getMemberId().equals(member.getMemberId())) {
             throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
@@ -245,11 +229,8 @@ public class ApplyService {
     }
 
     @Transactional
-    public void updatePostState(Member member,Long post_id, PostStatus postStatus) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post==null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+    public void updatePostState(Member member,Long postId, PostStatus postStatus) {
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         if (post.getMember() != member) {
             throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
@@ -262,11 +243,8 @@ public class ApplyService {
     }
 
     @Transactional
-    public void updatePostPeriod(Member member,Long post_id, PeriodReq req) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
-        if(post==null){
-            throw new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION);
-        }
+    public void updatePostPeriod(Member member,Long postId, PeriodReq req) {
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         if (post.getMember() != member) {
             throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }

--- a/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
@@ -133,7 +133,7 @@ public class ApplyService {
             stackNameList= null;
         }
 
-        return ApplicationRes.of(apply, categoryList, stackNameList,applyStackList);
+        return ApplicationRes.of(apply, categoryList, stackNameList, applyStackList);
     }
 
     @Transactional

--- a/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/service/ApplyService.java
@@ -37,7 +37,7 @@ import static com.gongjakso.server.global.exception.ErrorCode.INVALID_VALUE_EXCE
 
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ApplyService {
     private final ApplyRepository applyRepository;
@@ -46,6 +46,7 @@ public class ApplyService {
     private final StackNameRepository stackNameRepository;
     private final ApplyStackRepository applyStackRepository;
 
+    @Transactional
     public void save(Member member, Long post_id, ApplyReq req) {
         Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
         if(post==null){
@@ -146,6 +147,7 @@ public class ApplyService {
 
     }
 
+    @Transactional
     public List<String> changeCategoryType(Post post){
         List<Category> categoryList = categoryRepository.findCategoryByPost(post);
         if (categoryList == null) {
@@ -160,6 +162,7 @@ public class ApplyService {
         return stringTypelist;
     }
 
+    @Transactional
     public List<String> changeStackNameType(Post post){
         List<StackName> stackNameList = stackNameRepository.findStackNameByPost(post);
         List<String> stringTypelist = new ArrayList<>();
@@ -203,6 +206,7 @@ public class ApplyService {
         return ParticipationPageRes.of(participationLists, pageNo, size, totalPages, last);
     }
 
+    @Transactional
     private String decisionState(Apply apply) {
         if (apply.getApplyType().equals(ApplyType.OPEN_APPLY)) {
             return "열람 완료";
@@ -214,6 +218,7 @@ public class ApplyService {
         return "미열람";
     }
 
+    @Transactional
     public void updateState(Member member,Long apply_id, ApplyType applyType) {
         Apply apply = applyRepository.findById(apply_id).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_APPLY_EXCEPTION));
         //Check ApplyType
@@ -238,6 +243,7 @@ public class ApplyService {
 
     }
 
+    @Transactional
     public void updatePostState(Member member,Long post_id, PostStatus postStatus) {
         Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
         if(post==null){
@@ -254,6 +260,7 @@ public class ApplyService {
         post.setStatus(postStatus);
     }
 
+    @Transactional
     public void updatePostPeriod(Member member,Long post_id, PeriodReq req) {
         Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(post_id);
         if(post==null){

--- a/src/main/java/com/gongjakso/server/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/post/repository/PostRepository.java
@@ -14,7 +14,8 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Post findByPostId(Long postId);
-    Post findWithStackNameAndCategoryUsingFetchJoinByPostId(Long postId);
+
+    Optional<Post> findWithStackNameAndCategoryUsingFetchJoinByPostId(Long postId);
 
     Optional<Post> findByPostIdAndDeletedAtIsNull(Long postId);
     List<Post> findAllByFinishDateBetweenAndPostIdIn(LocalDateTime finishDate, LocalDateTime finishDate2, List<Long> postIdList);
@@ -130,6 +131,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     (@Param("searchWord") String searchWord, @Param("currentTimestamp") LocalDateTime currentTimestamp, @Param("status") PostStatus status, @Param("meetingCity") String meetingCity, @Param("meetingTown") String meetingTown, @Param("stackNameType") String stackNameType,Pageable pageable);
 
     List<Post> findAllByMemberAndStatusAndDeletedAtIsNull(Member member, PostStatus status);
-
-    List<Post> findAllByPostIdInAndStatusAndDeletedAtIsNull(List<Long> postId, PostStatus status);
 }

--- a/src/main/java/com/gongjakso/server/domain/post/service/PostService.java
+++ b/src/main/java/com/gongjakso/server/domain/post/service/PostService.java
@@ -12,6 +12,7 @@ import com.gongjakso.server.domain.post.enumerate.StackNameType;
 import com.gongjakso.server.domain.post.repository.PostRepository;
 import com.gongjakso.server.domain.post.repository.PostScrapRepository;
 import com.gongjakso.server.global.exception.ApplicationException;
+import com.gongjakso.server.global.exception.ErrorCode;
 import com.gongjakso.server.global.security.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,11 +73,8 @@ public class PostService {
     }
 
     @Transactional
-    public Optional<?> read(PrincipalDetails principalDetails, Long id, String role) {
-        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(id);
-        if (post == null) {
-            throw new ApplicationException(NOT_FOUND_POST_EXCEPTION);
-        }
+    public Optional<?> read(PrincipalDetails principalDetails, Long postId, String role) {
+        Post post = postRepository.findWithStackNameAndCategoryUsingFetchJoinByPostId(postId).orElseThrow(() -> new ApplicationException(ErrorCode.NOT_FOUND_POST_EXCEPTION));
         int current_person = (int) applyRepository.countApplyWithStackNameUsingFetchJoinByPost(post);
 
         post.updatePostView(post.getPostView());

--- a/src/main/java/com/gongjakso/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gongjakso/server/global/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
     //5000: Post Error
     NOT_POST_EXCEPTION(HttpStatus.BAD_REQUEST,5000,"공고를 더 이상 생성할 수 없습니다"),
     POST_VALUE_EXCEPTION(HttpStatus.BAD_REQUEST,5001,"올바르지 않은 요청 값입니다."),
-    NOT_FOUNT_SCRAP_EXCEPTION(HttpStatus.NOT_FOUND,5002,"스크랩 정보가 존재하지 않습니다.");
+    NOT_FOUNT_SCRAP_EXCEPTION(HttpStatus.NOT_FOUND,5002,"스크랩 정보가 존재하지 않습니다."),
+    ALREADY_FINISH_EXCEPTION(HttpStatus.BAD_REQUEST, 5003, "이미 모집 기간이 마감된 공고입니다.");
+
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;

--- a/src/main/java/com/gongjakso/server/global/util/email/EmailClient.java
+++ b/src/main/java/com/gongjakso/server/global/util/email/EmailClient.java
@@ -1,0 +1,42 @@
+package com.gongjakso.server.global.util.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailClient {
+
+    private final JavaMailSender mailSender;
+
+    public void sendOneEmail(String to) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+            // 수신자, 제목, 본문 등 설정
+            String subject = "";
+            String body = "";
+
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+            mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(body, true);
+
+            // Email 전송
+            mailSender.send(mimeMessage);
+
+        } catch (MessagingException e){
+            // TODO: 이메일 오류 핸들링 방법 정의 필요
+            log.error("Error sending email", e);
+        }
+
+    }
+
+    // TODO: 추후, 메일 전체 발송 메소드 개발 필요
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #115 , #116 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 지원 취소를 관리하기 위한 isCanceled 칼럼 추가 (default = false)
- 지원 취소 API 개발 (지원 취소 시, 공고 게시자에게 메일 가도록 설정되어 있음) -> 템플릿은 추후 추가 예정
- 지원자 현황 조회 API에서 지원 취소 여부 추가적으로 반환하도록 수정
- 지원자 현황 조회 API 리팩토링 (아래 스크린샷을 보면, != 로 확인하게 되면 참조 주소 기반으로 비교하게 됨. 이를 equals로 변경하더라도 객체이기 때문에 참조 주소 기반으로 변경되기에, pk 값으로 동일성 판단하도록 변경)

### 스크린샷 (선택)
![Screenshot 2024-05-01 at 3 45 08 PM](https://github.com/Gongjakso/server/assets/76556999/a7c1076d-04fe-4946-8de3-42b06e8b73e8)
![Screenshot 2024-05-01 at 3 44 50 PM](https://github.com/Gongjakso/server/assets/76556999/23dd2d50-9c8f-41b3-bfa7-7a234d4785bc)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
