### PR TITLE
refactor: pagination과 fetch join간의 문제점 해결하기 위한 쿼리 튜닝 진행

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
@@ -4,9 +4,12 @@ import com.gongjakso.server.domain.apply.entity.Apply;
 import com.gongjakso.server.domain.apply.enumerate.ApplyType;
 import com.gongjakso.server.domain.member.entity.Member;
 import com.gongjakso.server.domain.post.entity.Post;
+import com.gongjakso.server.domain.post.enumerate.PostStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,8 +25,10 @@ public interface ApplyRepository extends JpaRepository<Apply,Long> {
     Page<Apply> findAllByPost(Post post, Pageable pageable);
   
     List<Apply> findApplyByApplyTypeAndMemberAndIsCanceledFalse(ApplyType applyType, Member member);
-  
-    Page<Apply> findAllByMemberAndDeletedAtIsNullOrderByCreatedAtDesc(Member member, Pageable pageable);
+
+    @Query(value = "SELECT a FROM Apply a JOIN FETCH a.post p JOIN FETCH p.categories WHERE a.member = :member AND a.post.status IN :postStatus AND a.deletedAt IS NULL AND a.isCanceled = false ORDER BY a.createdAt DESC",
+            countQuery = "SELECT COUNT(DISTINCT a) FROM Apply a WHERE a.member = :member AND a.post.status IN :postStatus AND a.deletedAt IS NULL AND a.isCanceled = false")
+    Page<Apply> findAllByMemberAndPostStatusInAndDeletedAtIsNullAndIsCanceledFalseOrderByCreatedAtDesc(@Param("member") Member member, @Param("postStatus") List<PostStatus> postStatusList, Pageable pageable);
 
     Apply findApplyByMemberAndPost(Member member,Post post);
 

--- a/src/main/java/com/gongjakso/server/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/post/repository/PostRepository.java
@@ -132,5 +132,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByMemberAndStatusInAndDeletedAtIsNullOrderByCreatedAtDesc(Member member, List<PostStatus> statusList);
 
-    Page<Post> findAllByPostIdInOrMember(List<Long> postIdList, Member member, Pageable pageable);
+    Page<Post> findAllByPostIdInOrMemberAndDeletedAtIsNull(List<Long> postIdList, Member member, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
- #128 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 페이지네이션과 Fetch Join 간의 오류를 해결하기 위해 hibernate에서 메모리에 올릴 수 있는 사이즈를 1000으로 지정한 후, 네이티브 쿼리로 리팩토링

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
