### PR TITLE
feat: 포트폴리오 이름 입력 기능 추가

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
@@ -1,6 +1,7 @@
 package com.gongjakso.server.domain.portfolio.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
@@ -8,6 +9,7 @@ import lombok.Builder;
 
 @Builder
 public record PortfolioReq (
+        @Nullable
         String portfolioName,
         List<Education> educationList,
         List<Work> workList,

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
@@ -1,11 +1,14 @@
 package com.gongjakso.server.domain.portfolio.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record PortfolioReq (
+        String portfolioName,
         List<Education> educationList,
         List<Work> workList,
         List<Activty> activityList,
@@ -35,18 +38,21 @@ public record PortfolioReq (
             Boolean isActive
     ) {
     }
+
     public record Award (
             String contestName,
             String awardName,
             LocalDate awardDate
     ) {
     }
+
     public record Certificate (
             String name,
             String rating,
             LocalDate certificationDate
     ) {
     }
+
     public record Sns (
             String snsLink
     ) {

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/PortfolioRes.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/PortfolioRes.java
@@ -10,6 +10,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record PortfolioRes (
         Long id,
+        String portfolioName,
         List<PortfolioData.Education> educationList,
         List<PortfolioData.Work> workList,
         List<PortfolioData.Activity> activityList,
@@ -21,6 +22,7 @@ public record PortfolioRes (
         PortfolioData portfolioData = portfolio.getPortfolioData();
         return new PortfolioRes(
                 portfolio.getId(),
+                portfolioData.portfolioName(),
                 portfolioData.educationList(),
                 portfolioData.workList(),
                 portfolioData.activityList(),

--- a/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     Optional<Portfolio> findByIdAndDeletedAtIsNull(Long portfolioId);
+
+    long countByDeletedAtIsNull();
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -22,6 +22,12 @@ public class PortfolioService {
 
     // PortfolioReq -> PortfolioData 변환
     private PortfolioData convertToPortfolioData(PortfolioReq portfolioReq) {
+        String portfolioName = portfolioReq.portfolioName();
+        if (portfolioName == null || portfolioName.isEmpty()) {
+            long existingPortfolioCount = portfolioRepository.countByDeletedAtIsNull();
+            portfolioName = "포트폴리오 " + (existingPortfolioCount + 1);
+        }
+
         List<PortfolioData.Education> educationList = portfolioReq.educationList() != null
                 ? portfolioReq.educationList().stream()
                 .map(education -> new PortfolioData.Education(
@@ -82,7 +88,7 @@ public class PortfolioService {
                 .toList()
                 : List.of();
 
-        return new PortfolioData(educationList, workList, activityList, awardList, certificateList, snsList);
+        return new PortfolioData(portfolioName, educationList, workList, activityList, awardList, certificateList, snsList);
     }
 
     @Transactional

--- a/src/main/java/com/gongjakso/server/domain/portfolio/vo/PortfolioData.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/vo/PortfolioData.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record PortfolioData (
+        String portfolioName,
         List<Education> educationList,
         List<Work> workList,
         List<Activity> activityList,
@@ -17,6 +18,7 @@ public record PortfolioData (
             Boolean isActive
     ) {
     }
+
     public record Work (
             String company,
             String partition,
@@ -26,23 +28,27 @@ public record PortfolioData (
             String detail
     ) {
     }
+
     public record Activity (
             String name,
             Boolean isActive
     ) {
     }
+
     public record Award (
             String contestName,
             String awardName,
             LocalDate awardDate
     ) {
     }
+
     public record Certificate (
             String name,
             String rating,
             LocalDate certificationDate
     ) {
     }
+
     public record Sns (
             String snsLink
     ) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #200 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 포트폴리오 작성시 포트폴리오의 이름을 입력하는 기능 추가 구현
- 포트폴리오 이름 입력 란에 미입력시, 자동으로 기존 포트폴리오의 개수에서 n + 1 되어 "포트폴리오 n + 1" 형태로 자동 입력 (ex "포트폴리오 1")

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
