### PR TITLE
fix: PortfolioData에서 필드 분리, Education 데이터 타입 변경

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/apply/dto/response/ApplyRes.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/dto/response/ApplyRes.java
@@ -68,7 +68,7 @@ public record ApplyRes(
                 .memberId(apply.getMember().getId())
                 .leaderName(apply.getTeam().getMember().getName())
                 .portfolioId(apply.getPortfolioInfo().getPortfolio() != null ? apply.getPortfolioInfo().getPortfolio().getId() : null)
-                .portfolioName(apply.getPortfolioInfo().getPortfolio() != null ? apply.getPortfolioInfo().getPortfolio().getPortfolioData().portfolioName() : null)
+                .portfolioName(apply.getPortfolioInfo().getPortfolio() != null ? apply.getPortfolioInfo().getPortfolio().getPortfolioName() : null)
                 .isPrivate(apply.getPortfolioInfo().isPrivate())
                 .body(apply.getBody())
                 .status(apply.getStatus().getDescription())

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/request/PortfolioReq.java
@@ -21,7 +21,7 @@ public record PortfolioReq (
     public record Education (
             String school,
             String grade,
-            Boolean isActive
+            String state
     ) {
     }
 

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/PortfolioRes.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/PortfolioRes.java
@@ -22,7 +22,7 @@ public record PortfolioRes (
         PortfolioData portfolioData = portfolio.getPortfolioData();
         return new PortfolioRes(
                 portfolio.getId(),
-                portfolioData.portfolioName(),
+                portfolio.getPortfolioName(),
                 portfolioData.educationList(),
                 portfolioData.workList(),
                 portfolioData.activityList(),

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/SimplePortfolioRes.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/SimplePortfolioRes.java
@@ -12,7 +12,7 @@ public record SimplePortfolioRes(
     public static SimplePortfolioRes of(Portfolio portfolio) {
         return new SimplePortfolioRes(
                 portfolio.getId(),
-                portfolio.getPortfolioData().portfolioName(),
+                portfolio.getPortfolioName(),
                 portfolio.getModifiedAt()
         );
     }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
@@ -25,7 +25,7 @@ public class Portfolio extends BaseTimeEntity {
     @Column(name = "portfolio_id", nullable = false, columnDefinition = "bigint")
     private Long id;
 
-    @Column(name = "title", nullable = false, columnDefinition = "varchar(50)")
+    @Column(name = "portfolio_name", nullable = false, columnDefinition = "varchar(50)")
     private String portfolioName;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
@@ -25,6 +25,9 @@ public class Portfolio extends BaseTimeEntity {
     @Column(name = "portfolio_id", nullable = false, columnDefinition = "bigint")
     private Long id;
 
+    @Column(name = "title", nullable = false, columnDefinition = "varchar(50)")
+    private String portfolioName;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -34,12 +37,17 @@ public class Portfolio extends BaseTimeEntity {
     private PortfolioData portfolioData;
 
     @Builder
-    public Portfolio(Member member, PortfolioData portfolioData) {
+    public Portfolio(Member member, String portfolioName, PortfolioData portfolioData) {
         this.member = member;
+        this.portfolioName = portfolioName;
         this.portfolioData = portfolioData;
     }
 
-    public void update(PortfolioData updatedData) {
+    public void updateName(String updatedName) {
+        this.portfolioName = updatedName;
+    }
+
+    public void updateData(PortfolioData updatedData) {
         this.portfolioData = updatedData;
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/vo/PortfolioData.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/vo/PortfolioData.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public record PortfolioData (
-        String portfolioName,
         List<Education> educationList,
         List<Work> workList,
         List<Activity> activityList,
@@ -15,7 +14,7 @@ public record PortfolioData (
     public record Education (
             String school,
             String grade,
-            Boolean isActive
+            String state
     ) {
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

- #205
- #206  

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

Portfolio의 Education 내부 필드의 데이터타입 및 변수명 변경(Boolean -> String / isActive -> state)
Json타입 칼럼인 PortfolioData 내부 portfolioName 필드 별도 분리, 칼럼 생성하여 관리 

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
