### PR TITLE
Fix: 팀 조회 관련 오류 및 예외처리 추가

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/contest/entity/Contest.java
+++ b/src/main/java/com/gongjakso/server/domain/contest/entity/Contest.java
@@ -37,8 +37,8 @@ public class Contest extends BaseTimeEntity {
     private LocalDate finishedAt;
     @Column(name = "img_url",columnDefinition = "text")
     private String imgUrl;
-    @Column(name = "view",columnDefinition = "bigint")
-    private int view;
+    @Column(name = "view", nullable = false, columnDefinition = "bigint")
+    private Integer view;
 
     public void update(UpdateContestDto contest,String imgUrl){
         this.title= (contest.title()==null) ? this.title : contest.title();

--- a/src/main/java/com/gongjakso/server/domain/team/dto/request/TeamReq.java
+++ b/src/main/java/com/gongjakso/server/domain/team/dto/request/TeamReq.java
@@ -10,6 +10,7 @@ import com.gongjakso.server.domain.team.enumerate.MeetingMethod;
 import com.gongjakso.server.domain.team.vo.RecruitPart;
 import com.gongjakso.server.global.common.Position;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -39,9 +40,11 @@ public record TeamReq(
     @NotEmpty
     String meetingMethod,
 
+    @Nullable
     @Schema(description = "시/도", example = "서울특별시")
     String province,
 
+    @Nullable
     @Schema(description = "시/군/구", example = "강남구")
     String district,
 

--- a/src/main/java/com/gongjakso/server/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/gongjakso/server/domain/team/repository/TeamRepositoryImpl.java
@@ -60,9 +60,8 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
         Long total = queryFactory.select(team.count())
                 .from(team)
                 .where(
-                        province != null ? team.province.eq(province) : team.province.isNull(),
-                        district != null ? team.district.eq(district) : team.district.isNull(),
-                        team.deletedAt.isNull()
+                        team.deletedAt.isNull(),
+                        builder
                 )
                 .fetchOne();
 
@@ -99,10 +98,9 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
         Long total = queryFactory.select(team.count())
                 .from(team)
                 .where(
-                        province != null ? team.province.eq(province) : team.province.isNull(),
-                        district != null ? team.district.eq(district) : team.district.isNull(),
                         team.title.containsIgnoreCase(keyword),
-                        team.deletedAt.isNull()
+                        team.deletedAt.isNull(),
+                        builder
                 )
                 .fetchOne();
 

--- a/src/main/java/com/gongjakso/server/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/gongjakso/server/domain/team/repository/TeamRepositoryImpl.java
@@ -60,8 +60,8 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
         Long total = queryFactory.select(team.count())
                 .from(team)
                 .where(
-                        team.province.eq(province),
-                        team.district.eq(district),
+                        province != null ? team.province.eq(province) : team.province.isNull(),
+                        district != null ? team.district.eq(district) : team.district.isNull(),
                         team.deletedAt.isNull()
                 )
                 .fetchOne();
@@ -99,8 +99,8 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
         Long total = queryFactory.select(team.count())
                 .from(team)
                 .where(
-                        team.province.eq(province),
-                        team.district.eq(district),
+                        province != null ? team.province.eq(province) : team.province.isNull(),
+                        district != null ? team.district.eq(district) : team.district.isNull(),
                         team.title.containsIgnoreCase(keyword),
                         team.deletedAt.isNull()
                 )

--- a/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
@@ -158,6 +158,9 @@ public class TeamService {
                 .orElseThrow(() -> new ApplicationException(ErrorCode.CONTEST_NOT_FOUND_EXCEPTION));
         Team team = teamRepository.findByIdAndDeletedAtIsNull(teamId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.TEAM_NOT_FOUND_EXCEPTION));
+        if(!team.getContest().getId().equals(contestId)) {
+            throw new ApplicationException(ErrorCode.TEAM_NOT_FOUND_EXCEPTION);
+        }
 
         // Business Logic
         return TeamRes.of(team);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
> 
1. 팀 조회할때 province, district를 null로 보낼때 전체 조회가 되어야 하는데 string null로 보내야하고, db에도 string null이 들어가 있어야 해서 null로 조회할 수 있도록 수정하였습니다.
2. 공모전+팀 조회할 때 팀 id로만 조회되고 있어서 공모전 관련하여 예외처리 추가하였습니다.


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
