### PR TITLE
fix: 팀에 대한 사용자 역할 추가 반환

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyRepositoryCustom {
     Boolean existsByMemberIdAndTeamIdAndDeletedAtIsNull(Long memberId, Long teamId);
     Optional<Apply> findByIdAndDeletedAtIsNull(Long applyId);
+    Optional<Apply> findByTeamId(Long teamId);
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyRepositoryCustom {
     Boolean existsByMemberIdAndTeamIdAndDeletedAtIsNull(Long memberId, Long teamId);
     Optional<Apply> findByIdAndDeletedAtIsNull(Long applyId);
-    Optional<Apply> findByTeamId(Long teamId);
+    Optional<Apply> findByTeamIdAndDeletedAtIsNull(Long teamId);
 }

--- a/src/main/java/com/gongjakso/server/domain/team/controller/TeamController.java
+++ b/src/main/java/com/gongjakso/server/domain/team/controller/TeamController.java
@@ -80,9 +80,10 @@ public class TeamController {
 
     @Operation(summary = "팀 조회 API", description = "특정 공모전에 해당하는 팀을 조회하는 API")
     @GetMapping("/contest/{contest_id}/team/{team_id}")
-    public ApplicationResponse<TeamRes> getTeam(@PathVariable(value = "contest_id") Long contestId,
+    public ApplicationResponse<TeamRes> getTeam(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                @PathVariable(value = "contest_id") Long contestId,
                                                 @PathVariable(value = "team_id") Long teamId) {
-        return ApplicationResponse.ok(teamService.getTeam(contestId, teamId));
+        return ApplicationResponse.ok(teamService.getTeam(principalDetails == null ? null : principalDetails.getMember(), contestId, teamId));
     }
 
     @Operation(summary = "팀 리스트 조회 API", description = "특정 공모전에 해당하는 팀 리스트를 조회하는 API (오프셋 기반 페이지네이션)")

--- a/src/main/java/com/gongjakso/server/domain/team/dto/response/TeamRes.java
+++ b/src/main/java/com/gongjakso/server/domain/team/dto/response/TeamRes.java
@@ -70,7 +70,10 @@ public record TeamRes(
     int scrapCount,
 
     @Schema(description = "조회 수", example = "100")
-    int viewCount
+    int viewCount,
+
+    @Schema(description = "사용자 역할", example = "LEADER")
+    String teamRole
 ) {
 
     @Builder
@@ -96,7 +99,7 @@ public record TeamRes(
 
     }
 
-    public static TeamRes of(Team team) {
+    public static TeamRes of(Team team, String teamRole) {
         List<RecruitPartRes> recruitPartRes = (team.getRecruitPart() != null) ? team.getRecruitPart().stream()
                 .map(RecruitPartRes::of)
                 .toList() : null;
@@ -120,6 +123,7 @@ public record TeamRes(
                 .finishedAt(team.getFinishedAt())
                 .channelLink(team.getChannelLink())
                 .scrapCount(team.getScrapCount())
+                .teamRole(teamRole)
                 .build();
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
@@ -1,5 +1,7 @@
 package com.gongjakso.server.domain.team.service;
 
+import com.gongjakso.server.domain.apply.entity.Apply;
+import com.gongjakso.server.domain.apply.repository.ApplyRepository;
 import com.gongjakso.server.domain.contest.entity.Contest;
 import com.gongjakso.server.domain.contest.repository.ContestRepository;
 import com.gongjakso.server.domain.member.entity.Member;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final ContestRepository contestRepository;
     private final ScrapRepository scrapRepository;
+    private final ApplyRepository applyRepository;
 
     @Transactional
     public TeamRes createTeam(Member member, Long contestId, TeamReq teamReq) {
@@ -41,7 +45,7 @@ public class TeamService {
         Team savedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(savedTeam);
+        return TeamRes.of(savedTeam, "LEADER");
     }
 
     @Transactional
@@ -63,7 +67,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam);
+        return TeamRes.of(updatedTeam, "LEADER");
     }
 
     @Transactional
@@ -86,7 +90,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam);
+        return TeamRes.of(updatedTeam, "LEADER");
     }
 
     @Transactional
@@ -108,7 +112,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam);
+        return TeamRes.of(updatedTeam, "LEADER");
     }
 
     @Transactional
@@ -130,7 +134,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam);
+        return TeamRes.of(updatedTeam, "LEADER");
     }
 
     @Transactional
@@ -152,7 +156,7 @@ public class TeamService {
     }
 
     // TODO: 조회수 관련 로직 도입 및 @Transactional 도입 필요
-    public TeamRes getTeam(Long contestId, Long teamId) {
+    public TeamRes getTeam(Member member, Long contestId, Long teamId) {
         // Validation
         contestRepository.findByIdAndDeletedAtIsNull(contestId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.CONTEST_NOT_FOUND_EXCEPTION));
@@ -162,8 +166,19 @@ public class TeamService {
             throw new ApplicationException(ErrorCode.TEAM_NOT_FOUND_EXCEPTION);
         }
 
+        List<Member> appliers = applyRepository.findByTeamId(teamId).stream()
+                .map(Apply::getMember)
+                .toList();
+
+        String teamRole = "GENERAL";
+        if(member != null && team.getMember().getId().equals(member.getId())){
+            teamRole = "LEADER";
+        }else if(member != null && appliers.stream().anyMatch(applier -> applier.getId().equals(member.getId()))){
+            teamRole = "APPLIER";
+        }
+
         // Business Logic
-        return TeamRes.of(team);
+        return TeamRes.of(team, teamRole);
     }
 
     public Page<SimpleTeamRes> getTeamListWithContest(Long contestId, String province, String district, Pageable pageable) {

--- a/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
@@ -166,7 +166,7 @@ public class TeamService {
             throw new ApplicationException(ErrorCode.TEAM_NOT_FOUND_EXCEPTION);
         }
 
-        List<Member> appliers = applyRepository.findByTeamId(teamId).stream()
+        List<Member> appliers = applyRepository.findByTeamIdAndDeletedAtIsNull(teamId).stream()
                 .map(Apply::getMember)
                 .toList();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

- #212 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Team에 대한 사용자 역할이 팀장/지원자/일반 사용자 인지 구분하는 필드 추가 반환하도록 수정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
