### PR TITLE
fix: team 조회 시 지원상태면 applyStatus와 applyId 반환하도록 수정

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/apply/enumerate/ApplyStatus.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/enumerate/ApplyStatus.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ApplyStatus {
-    COMPLETED("지원 완료"),
-    ACCEPTED("합격"),
-    REJECTED("불합격");
+    COMPLETED("합류 대기중"),
+    ACCEPTED("합류 완료"),
+    REJECTED("미선발");
 
     private final String description;
 }

--- a/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/com/gongjakso/server/domain/apply/repository/ApplyRepository.java
@@ -9,4 +9,5 @@ public interface ApplyRepository extends JpaRepository<Apply, Long>, ApplyReposi
     Boolean existsByMemberIdAndTeamIdAndDeletedAtIsNull(Long memberId, Long teamId);
     Optional<Apply> findByIdAndDeletedAtIsNull(Long applyId);
     Optional<Apply> findByTeamIdAndDeletedAtIsNull(Long teamId);
+    Optional<Apply> findByTeamIdAndMemberIdAndDeletedAtIsNull(Long teamId, Long memberId);
 }

--- a/src/main/java/com/gongjakso/server/domain/team/dto/response/TeamRes.java
+++ b/src/main/java/com/gongjakso/server/domain/team/dto/response/TeamRes.java
@@ -3,6 +3,7 @@ package com.gongjakso.server.domain.team.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.gongjakso.server.domain.apply.entity.Apply;
 import com.gongjakso.server.domain.team.entity.Team;
 import com.gongjakso.server.domain.team.vo.RecruitPart;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -82,7 +83,13 @@ public record TeamRes(
     int viewCount,
 
     @Schema(description = "사용자 역할", example = "LEADER")
-    String teamRole
+    String teamRole,
+
+    @Schema(description = "지원 상태", example = "합류 대기중 | 합류 완료 | 미선발")
+    String applyStatus,
+
+    @Schema(description = "지원 ID", example = "1")
+    Long applyId
 ) {
 
     @Builder
@@ -108,7 +115,7 @@ public record TeamRes(
 
     }
 
-    public static TeamRes of(Team team, String teamRole) {
+    public static TeamRes of(Team team, String teamRole, Apply apply) {
         List<RecruitPartRes> recruitPartRes = (team.getRecruitPart() != null) ? team.getRecruitPart().stream()
                 .map(RecruitPartRes::of)
                 .toList() : null;
@@ -136,6 +143,8 @@ public record TeamRes(
                 .contestLink(team.getContest().getContestLink())
                 .scrapCount(team.getScrapCount())
                 .teamRole(teamRole)
+                .applyStatus(apply != null ? apply.getStatus().getDescription() : null)
+                .applyId(apply != null ? apply.getId() : null)
                 .build();
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/gongjakso/server/domain/team/service/TeamService.java
@@ -46,7 +46,7 @@ public class TeamService {
         Team savedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(savedTeam, "LEADER");
+        return TeamRes.of(savedTeam, "LEADER", null);
     }
 
     @Transactional
@@ -68,7 +68,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam, "LEADER");
+        return TeamRes.of(updatedTeam, "LEADER", null);
     }
 
     @Transactional
@@ -91,7 +91,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam, "LEADER");
+        return TeamRes.of(updatedTeam, "LEADER", null);
     }
 
     @Transactional
@@ -113,7 +113,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam, "LEADER");
+        return TeamRes.of(updatedTeam, "LEADER", null);
     }
 
     @Transactional
@@ -135,7 +135,7 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam, "LEADER");
+        return TeamRes.of(updatedTeam, "LEADER", null);
     }
 
     @Transactional
@@ -172,14 +172,18 @@ public class TeamService {
                 .toList();
 
         String teamRole = "GENERAL";
+        Apply apply = null;
+
         if(member != null && team.getMember().getId().equals(member.getId())){
             teamRole = "LEADER";
         }else if(member != null && appliers.stream().anyMatch(applier -> applier.getId().equals(member.getId()))){
             teamRole = "APPLIER";
+            apply = applyRepository.findByTeamIdAndMemberIdAndDeletedAtIsNull(teamId, member.getId())
+                    .orElseThrow(() -> new ApplicationException(ErrorCode.APPLY_NOT_FOUND_EXCEPTION));
         }
 
         // Business Logic
-        return TeamRes.of(team, teamRole);
+        return TeamRes.of(team, teamRole, apply);
     }
 
     public Page<SimpleTeamRes> getTeamListWithContest(Long contestId, String province, String district, Pageable pageable) {
@@ -298,6 +302,6 @@ public class TeamService {
         Team updatedTeam = teamRepository.save(team);
 
         // Response
-        return TeamRes.of(updatedTeam, "LEADER");
+        return TeamRes.of(updatedTeam, "LEADER", null);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
- #226 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
team 조회 시 지원상태면 applyStatus와 applyId 반환하도록 수정하였습니다!

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
