### PR TITLE
fix: Portfolio 존재 여부 추가 반환하도록 수정

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/SimplePortfolioRes.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/SimplePortfolioRes.java
@@ -1,19 +1,23 @@
 package com.gongjakso.server.domain.portfolio.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gongjakso.server.domain.portfolio.entity.Portfolio;
 
 import java.time.LocalDateTime;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SimplePortfolioRes(
         Long PortfolioId,
         String PortfolioName,
-        LocalDateTime modifiedAt
+        LocalDateTime modifiedAt,
+        Boolean isRegistered
 ) {
-    public static SimplePortfolioRes of(Portfolio portfolio) {
+    public static SimplePortfolioRes of(Portfolio portfolio, Boolean isRegistered) {
         return new SimplePortfolioRes(
-                portfolio.getId(),
-                portfolio.getPortfolioName(),
-                portfolio.getModifiedAt()
+                isRegistered ? portfolio.getId() : null,
+                isRegistered ? portfolio.getPortfolioName() : null,
+                isRegistered ? portfolio.getModifiedAt() : null,
+                isRegistered
         );
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -164,8 +164,13 @@ public class PortfolioService {
 
     public List<SimplePortfolioRes> getMyPortfolios(Member member) {
         List<Portfolio> portfolioList = portfolioRepository.findByMemberAndDeletedAtIsNull(member);
+
+        if (portfolioList.isEmpty()) {
+            return List.of(SimplePortfolioRes.of(null, false));
+        }
+
         return portfolioList.stream()
-                .map(SimplePortfolioRes::of)
+                .map(portfolio -> SimplePortfolioRes.of(portfolio, true))
                 .toList();
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

## 📝 작업 내용
> Portfolio 존재 여부 `isRegistered` 추가 반환하도록 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
> Ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
