### PR TITLE
fix : exist portfolio delete/find api 수정

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
@@ -72,7 +72,7 @@ public class PortfolioController {
 
     @Operation(description = "포트폴리오 파일 및 링크 업로드 삭제 API")
     @DeleteMapping("/exist-portfolio/{portfolio_id}")
-    public ApplicationResponse<Void> deleteExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") DataType dataType){
+    public ApplicationResponse<Void> deleteExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") String dataType){
         portfolioService.deleteExistPortfolio(principalDetails.getMember(),portfolioId,dataType);
         return ApplicationResponse.ok();
     }
@@ -86,7 +86,7 @@ public class PortfolioController {
 
     @Operation(description = "포트폴리오 파일 및 링크 업로드 가져오기 API")
     @GetMapping("/exist-portfolio/{portfolio_id}")
-    public ApplicationResponse<ExistPortfolioRes> findExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") DataType dataType){
+    public ApplicationResponse<ExistPortfolioRes> findExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") String dataType){
         return ApplicationResponse.ok(portfolioService.findExistPorfolio(principalDetails.getMember(),portfolioId,dataType));
     }
 

--- a/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
@@ -72,8 +72,8 @@ public class PortfolioController {
 
     @Operation(description = "포트폴리오 파일 및 링크 업로드 삭제 API")
     @DeleteMapping("/exist-portfolio/{portfolio_id}")
-    public ApplicationResponse<Void> deleteExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("portfolio_id") Long portfolioId){
-        portfolioService.deleteExistPortfolio(principalDetails.getMember(),portfolioId);
+    public ApplicationResponse<Void> deleteExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails,@PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") DataType dataType){
+        portfolioService.deleteExistPortfolio(principalDetails.getMember(),portfolioId,dataType);
         return ApplicationResponse.ok();
     }
 

--- a/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/controller/PortfolioController.java
@@ -4,6 +4,7 @@ import com.gongjakso.server.domain.portfolio.dto.request.PortfolioReq;
 import com.gongjakso.server.domain.portfolio.dto.response.ExistPortfolioRes;
 import com.gongjakso.server.domain.portfolio.dto.response.PortfolioRes;
 import com.gongjakso.server.domain.portfolio.dto.response.SimplePortfolioRes;
+import com.gongjakso.server.domain.portfolio.enumerate.DataType;
 import com.gongjakso.server.domain.portfolio.service.PortfolioService;
 import com.gongjakso.server.global.common.ApplicationResponse;
 import com.gongjakso.server.global.security.PrincipalDetails;
@@ -85,8 +86,8 @@ public class PortfolioController {
 
     @Operation(description = "포트폴리오 파일 및 링크 업로드 가져오기 API")
     @GetMapping("/exist-portfolio/{portfolio_id}")
-    public ApplicationResponse<ExistPortfolioRes> findExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("portfolio_id") Long portfolioId){
-        return ApplicationResponse.ok(portfolioService.findExistPorfolio(principalDetails.getMember(),portfolioId));
+    public ApplicationResponse<ExistPortfolioRes> findExistPortfolio(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("portfolio_id") Long portfolioId, @RequestParam(name = "dataType") DataType dataType){
+        return ApplicationResponse.ok(portfolioService.findExistPorfolio(principalDetails.getMember(),portfolioId,dataType));
     }
 
 

--- a/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/ExistPortfolioRes.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/dto/response/ExistPortfolioRes.java
@@ -1,7 +1,9 @@
 package com.gongjakso.server.domain.portfolio.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.gongjakso.server.domain.portfolio.entity.Portfolio;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ExistPortfolioRes(
         String fileUri,
         String notionUri

--- a/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/entity/Portfolio.java
@@ -58,11 +58,10 @@ public class Portfolio extends BaseTimeEntity {
         this.fileUri = fileUri;
         this.notionUri = notionUri;
     }
-    public void updatePortfolioUri(Portfolio portfolio, String fileUri, String notionUri) {
+    public void updatePortfolioUri(String fileUri, String notionUri) {
         this.fileUri = (fileUri == null) ? this.fileUri : fileUri;
         this.notionUri = (notionUri == null) ? this.notionUri : notionUri;
     }
-
 
     public void updateName(String updatedName) {
         this.portfolioName = updatedName;
@@ -70,5 +69,12 @@ public class Portfolio extends BaseTimeEntity {
 
     public void updateData(PortfolioData updatedData) {
         this.portfolioData = updatedData;
+    }
+
+    public void setFileUri(String fileUri){
+        this.fileUri=fileUri;
+    }
+    public void setNotionUri(String notionUri){
+        this.notionUri=notionUri;
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/enumerate/DataType.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/enumerate/DataType.java
@@ -1,5 +1,5 @@
 package com.gongjakso.server.domain.portfolio.enumerate;
 
 public enum DataType {
-    FILE,NOTION,HYBIRD
+    FILE,NOTION,HYBRID
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/enumerate/DataType.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/enumerate/DataType.java
@@ -1,0 +1,5 @@
+package com.gongjakso.server.domain.portfolio.enumerate;
+
+public enum DataType {
+    FILE,NOTION,HYBIRD
+}

--- a/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface PortfolioRepositoryCustom {
     List<Portfolio> findByMemberAndDeletedAtIsNull(Member member);
-    Boolean existsExistPortfolioByMember(Member member);
+    Boolean hasExistPortfolioByMember(Member member,String condition);
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.gongjakso.server.domain.portfolio.repository;
 
 import com.gongjakso.server.domain.member.entity.Member;
 import com.gongjakso.server.domain.portfolio.entity.Portfolio;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -21,12 +22,21 @@ public class PortfolioRepositoryImpl {
                 .fetch();
     }
 
-    public Boolean existsExistPortfolioByMember(Member member){
+    public Boolean hasExistPortfolioByMember(Member member,String condition){
         return queryFactory
                 .selectFrom(portfolio)
                 .where(portfolio.member.eq(member)
-                        .and(portfolio.fileUri.isNotNull().or(portfolio.notionUri.isNotNull()))
+                        .and(conditionEq(condition))
                         .and(portfolio.deletedAt.isNull()))
                 .fetchFirst()!=null;
+    }
+
+    public BooleanExpression conditionEq(String condition){
+        if(condition.equals("or")){
+            return portfolio.fileUri.isNotNull().or(portfolio.notionUri.isNotNull());
+        }else if (condition.equals("and")){
+            return portfolio.fileUri.isNull().and(portfolio.notionUri.isNull());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -262,9 +262,9 @@ public class PortfolioService {
         }
         DataType type = DataType.valueOf(dataType.toUpperCase());
         if (type.equals(DataType.FILE)){
-            return new ExistPortfolioRes(null,portfolio.getNotionUri());
-        } else if (type.equals(DataType.NOTION)) {
             return new ExistPortfolioRes(portfolio.getFileUri(),null);
+        } else if (type.equals(DataType.NOTION)) {
+            return new ExistPortfolioRes(null,portfolio.getNotionUri());
         }else {
             return new ExistPortfolioRes(portfolio.getFileUri(),portfolio.getNotionUri());
         }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -12,6 +12,7 @@ import com.gongjakso.server.domain.portfolio.repository.PortfolioRepository;
 import com.gongjakso.server.global.exception.ApplicationException;
 import com.gongjakso.server.global.exception.ErrorCode;
 import java.util.List;
+import java.util.Locale;
 
 import com.gongjakso.server.global.util.s3.S3Client;
 import lombok.RequiredArgsConstructor;
@@ -196,12 +197,13 @@ public class PortfolioService {
     }
 
     @Transactional
-    public void deleteExistPortfolio(Member member, Long id, DataType dataType){
+    public void deleteExistPortfolio(Member member, Long id, String dataType){
         Portfolio portfolio = portfolioRepository.findById(id).orElseThrow(()-> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
         if(!member.getId().equals(portfolio.getMember().getId())){
             throw new ApplicationException(ErrorCode.UNAUTHORIZED_EXCEPTION);
         }
-        if (dataType.equals(DataType.FILE)){
+        DataType type = DataType.valueOf(dataType.toUpperCase());
+        if (type.equals(DataType.FILE)){
             //file delete
             if(portfolio.getFileUri()==null){
                 throw new ApplicationException(ErrorCode.FILE_NOT_FOUND_EXCEPTION);
@@ -212,7 +214,7 @@ public class PortfolioService {
             if(portfolioRepository.hasExistPortfolioByMember(member,"and")){
                 portfolioRepository.delete(portfolio);
             }
-        } else if (dataType.equals(DataType.NOTION)) {
+        } else if (type.equals(DataType.NOTION)) {
             //notion delete
             if(portfolio.getNotionUri()==null){
                 throw new ApplicationException(ErrorCode.NOTION_NOT_FOUND_EXCEPTION);
@@ -252,15 +254,16 @@ public class PortfolioService {
         portfolioRepository.save(portfolio);
     }
 
-    public ExistPortfolioRes findExistPorfolio(Member member, Long id, DataType dataType){
+    public ExistPortfolioRes findExistPorfolio(Member member, Long id, String dataType){
         //Validation
         Portfolio portfolio = portfolioRepository.findById(id).orElseThrow(()-> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
         if (!portfolio.getMember().getId().equals(member.getId())) {
             throw new ApplicationException(ErrorCode.FORBIDDEN_EXCEPTION);
         }
-        if (dataType.equals(DataType.FILE)){
+        DataType type = DataType.valueOf(dataType.toUpperCase());
+        if (type.equals(DataType.FILE)){
             return new ExistPortfolioRes(null,portfolio.getNotionUri());
-        } else if (dataType.equals(DataType.NOTION)) {
+        } else if (type.equals(DataType.NOTION)) {
             return new ExistPortfolioRes(portfolio.getFileUri(),null);
         }else {
             return new ExistPortfolioRes(portfolio.getFileUri(),portfolio.getNotionUri());

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -6,6 +6,7 @@ import com.gongjakso.server.domain.portfolio.dto.response.ExistPortfolioRes;
 import com.gongjakso.server.domain.portfolio.dto.response.PortfolioRes;
 import com.gongjakso.server.domain.portfolio.dto.response.SimplePortfolioRes;
 import com.gongjakso.server.domain.portfolio.entity.Portfolio;
+import com.gongjakso.server.domain.portfolio.enumerate.DataType;
 import com.gongjakso.server.domain.portfolio.vo.PortfolioData;
 import com.gongjakso.server.domain.portfolio.repository.PortfolioRepository;
 import com.gongjakso.server.global.exception.ApplicationException;
@@ -226,13 +227,19 @@ public class PortfolioService {
         portfolioRepository.save(portfolio);
     }
 
-    public ExistPortfolioRes findExistPorfolio(Member member, Long id){
+    public ExistPortfolioRes findExistPorfolio(Member member, Long id, DataType dataType){
         //Validation
         Portfolio portfolio = portfolioRepository.findById(id).orElseThrow(()-> new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION));
         if (!portfolio.getMember().getId().equals(member.getId())) {
             throw new ApplicationException(ErrorCode.FORBIDDEN_EXCEPTION);
         }
-        return new ExistPortfolioRes(portfolio.getFileUri(),portfolio.getNotionUri());
+        if (dataType.equals(DataType.FILE)){
+            return new ExistPortfolioRes(null,portfolio.getNotionUri());
+        } else if (dataType.equals(DataType.NOTION)) {
+            return new ExistPortfolioRes(portfolio.getFileUri(),null);
+        }else {
+            return new ExistPortfolioRes(portfolio.getFileUri(),portfolio.getNotionUri());
+        }
     }
 
 }

--- a/src/main/java/com/gongjakso/server/global/exception/ErrorCode.java
+++ b/src/main/java/com/gongjakso/server/global/exception/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
     PORTFOLIO_UPDATE_FAILED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, 6002, "포트폴리오 수정에 실패했습니다."),
     INVALID_PORTFOLIO_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, 6003, "유효하지 않은 포트폴리오 요청입니다."),
     PORTFOLIO_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, 6004, "포트폴리오에 대한 권한이 없습니다."),
+    FILE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 6005, "존재하지 않는 파일 리소스입니다."),
+    NOTION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 6005, "존재하지 않는 노션 링크 리소스입니다."),
 
     //7000: Apply Error
     APPLY_PERIOD_EXPIRED_EXCEPTION(HttpStatus.BAD_REQUEST,7000,"지원 기간이 지났습니다"),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #246 

## 📝 작업 내용
> delete api에서 삭제할 데이터 타입을 받은 후 해당 데이터 null값 처리 후 file,notionUri 모두 null인지 판별하여 모두 null이면 해당 열을 삭제하도록 진행하였습니다. / 두 타입 모두 삭제할 경우에는 기존 방식대로 삭제 진행했습니다.

> find api에서 요청한 데이터 타입만 정보 반환하도록 수정하였습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
