### PR TITLE
fix : 존재하는 포트폴리오 삭제 오류 수정

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryCustom.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryCustom.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface PortfolioRepositoryCustom {
     List<Portfolio> findByMemberAndDeletedAtIsNull(Member member);
-    Boolean hasExistPortfolioByMember(Member member,String condition);
+    Boolean hasExistPortfolioByMember(Member member);
+    Boolean hasExistPortfolioById(Member member,Long id);
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryImpl.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/repository/PortfolioRepositoryImpl.java
@@ -22,21 +22,24 @@ public class PortfolioRepositoryImpl implements PortfolioRepositoryCustom {
                 .fetch();
     }
 
-    public Boolean hasExistPortfolioByMember(Member member,String condition){
+    public Boolean hasExistPortfolioByMember(Member member){
         return queryFactory
                 .selectFrom(portfolio)
                 .where(portfolio.member.eq(member)
-                        .and(conditionEq(condition))
+                        .and(portfolio.fileUri.isNotNull().or(portfolio.notionUri.isNotNull()))
                         .and(portfolio.deletedAt.isNull()))
                 .fetchFirst()!=null;
     }
 
-    public BooleanExpression conditionEq(String condition){
-        if(condition.equals("or")){
-            return portfolio.fileUri.isNotNull().or(portfolio.notionUri.isNotNull());
-        }else if (condition.equals("and")){
-            return portfolio.fileUri.isNull().and(portfolio.notionUri.isNull());
-        }
-        return null;
+    public Boolean hasExistPortfolioById(Member member,Long id){
+        return queryFactory
+                .selectFrom(portfolio)
+                .where(portfolio.member.eq(member)
+                        .and(portfolio.id.eq(id))
+                        .and(portfolio.fileUri.isNull())
+                        .and(portfolio.notionUri.isNull())
+                        .and(portfolio.portfolioData.isNull())
+                        .and(portfolio.deletedAt.isNull()))
+                .fetchFirst()!=null;
     }
 }

--- a/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/gongjakso/server/domain/portfolio/service/PortfolioService.java
@@ -181,7 +181,7 @@ public class PortfolioService {
     public void saveExistPortfolio(Member member, MultipartFile file, String notionUri){
         //등록된 파일이나 노션 링크 있는지 확인
         //Validation
-        Boolean isExist = portfolioRepository.hasExistPortfolioByMember(member,"or");
+        Boolean isExist = portfolioRepository.hasExistPortfolioByMember(member);
         if (isExist){
             throw new ApplicationException(ErrorCode.ALREADY_EXIST_EXCEPTION);
         }
@@ -212,20 +212,20 @@ public class PortfolioService {
             s3Client.delete(portfolio.getFileUri());
             portfolio.setFileUri(null);
             //file,notion all null
-            if(portfolioRepository.hasExistPortfolioByMember(member,"and")){
+            if(portfolioRepository.hasExistPortfolioById(member,id)){
                 portfolioRepository.delete(portfolio);
             }
-        } else if (type.equals(DataType.NOTION)) {
+        }else if (type.equals(DataType.NOTION)) {
             //notion delete
             if(portfolio.getNotionUri()==null){
                 throw new ApplicationException(ErrorCode.NOTION_NOT_FOUND_EXCEPTION);
             }
             portfolio.setNotionUri(null);
             //file,notion all null
-            if(portfolioRepository.hasExistPortfolioByMember(member,"and")){
+            if(portfolioRepository.hasExistPortfolioById(member,id)){
                 portfolioRepository.delete(portfolio);
             }
-        }else {
+        }else if(type.equals(DataType.HYBRID)) {
             //file,notion delete
             if(portfolio.getFileUri()==null || portfolio.getNotionUri()==null){
                 throw new ApplicationException(ErrorCode.NOT_FOUND_EXCEPTION);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #259 

## 📝 작업 내용
> 양식 포트폴리오가 존재할 때, 존재하는 포트폴리오에서 노션, 링크 중 하나만 삭제요청 시 레코드자체가 삭제되는 오류 수정하였습니다.
querydsl에서 양식 포트폴리오 조건을 넣지 않아 발생한 문제 같아 수정했습니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

