### PR TITLE
fix : contest search api에서 defaultValue 값 수정

### DIFF
--- a/src/main/java/com/gongjakso/server/domain/contest/controller/ContestController.java
+++ b/src/main/java/com/gongjakso/server/domain/contest/controller/ContestController.java
@@ -43,7 +43,7 @@ public class ContestController {
     @Operation(description = "공모전 검색 API")
     @GetMapping("/search")
     public ApplicationResponse<ContestListRes> search(
-            @RequestParam(name = "word", defaultValue = "공모전") String word,
+            @RequestParam(name = "word", defaultValue = "") String word,
             @RequestParam(name = "sortAt", defaultValue = "createdAt") String sortAt,
             @PageableDefault(size = 12,page = 0) Pageable pageable){
         return ApplicationResponse.ok(contestService.search(word,sortAt,pageable));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close #263 

## 📝 작업 내용
>contest search api에서 defalutValue="공모전"으로 되어있어 처음 화면에 모든 공모전이 안보이는 오류가 발생하여 수정하였습니다.

### 스크린샷 (선택)


